### PR TITLE
NikoHomeControlMonitor with asyncio

### DIFF
--- a/nikohomecontrol/nhcmonitor.py
+++ b/nikohomecontrol/nhcmonitor.py
@@ -11,6 +11,7 @@ Author: Jeroen Vaes
 
 import asyncio
 import json
+import inspect
 
 class Event:
     def __init__(self, type, data):
@@ -30,53 +31,63 @@ class Event:
         return self._state['value2']
 
 class NikoHomeControlMonitor:
-    @classmethod
-    async def create(cls, ip, port):
-        self = NikoHomeControlMonitor()
+    def __init__(self, ip, port):
         self._callback = []
-        self._reader, self._writer = await asyncio.open_connection(ip, port)
-
-        return self
+        self._ip = ip
+        self._port = port
 
     def add_callback(self, func):
-        self._callback.append(func)
+        """Add callback function for events."""
+        if inspect.isfunction(func) \
+                and len(inspect.signature(func).parameters) == 1:
+            self._callback.append(func)
+        else:
+            raise Exception("Only use functions with 1 parameter as callback.")
 
     async def _listen(self):
-        """Listen for events."""
+        """
+        Listen for events. When an event is received, call callback functions.
+        """
         s = '{"cmd":"startevents"}'
 
-        self._writer.write(s.encode())
-        await self._writer.drain()
+        try:
+            self._reader, self._writer = \
+                await asyncio.open_connection(self._ip, self._port)
 
-        async for line in self._reader:
-            try:
+            self._writer.write(s.encode())
+            await self._writer.drain()
+
+            async for line in self._reader:
                 message = json.loads(line.decode())
-                if "event" in message and message["event"] == "listactions":
+                if "event" in message \
+                        and message["event"] != "startevents":
                     event = Event(message["event"], message["data"])
                     for data in message["data"]:
                         event = Event(message["event"], data)
                         for func in self._callback:
-                            await func(event)
-            except Exception as e:
-                print(e)
-    
+                            func(event)
+        finally:
+            self._writer.close()
+            await self._writer.wait_closed()
+
     def start_listener(self):
+        """Create an asyncio task for the listener."""
         self._listen_task = asyncio.create_task(self._listen())
 
     def stop_listener(self):
+        """Stop the listener."""
         self._listen_task.cancel()
 
-async def callback(event):
-    print(event.type)
-    print(event.id)
-    print(event.value1)
+def callback(event):
+    print(f"Event received! Type: {event.type}, " \
+          "Id: {event.id}, Value: {event.value1}")
 
 async def main():
-    mon = await NikoHomeControlMonitor.create(ip='192.168.4.6', port=8000)
+    mon = NikoHomeControlMonitor(ip='192.168.4.6', port=8000)
     mon.add_callback(callback)
     mon.start_listener()
 
-    await asyncio.sleep(10)
+    await asyncio.sleep(60)
     mon.stop_listener()
 
 asyncio.run(main())


### PR DESCRIPTION
This PR contains a version of NikoHomeControlMonitor using non-blocking asyncio sockets. This is to help solve this Home Assistant issue: https://github.com/home-assistant/core/issues/98934. The previous version of the NikoHomeControlMonitor-class still blocked the main thread because of the usage of nclib, so it was not usable. This version takes a different approach.

In order to keep with the architecture fo the rest of the library, I created an Event data class to wrap the events in (similarly to e.g. the Action class). An Event is propagated to registered callback-functions. The NikoHomeControlConnection-class is not used as we use asyncio instead of nclib.

A small example is included.

As I only have lights (and ventilation) modules I was unable to test the events with e.g. thermostats. As such I don't know for certain if the Event-class design holds up for other types. If someone is able to give some examples of other types of events I can update the code accordingly.

Shoutout to @VandeurenGlenn for testing & sparring.

Thanks for taking this PR into consideration, always open to clarifications or changes as needed.